### PR TITLE
Add empty value for env, fixes #1

### DIFF
--- a/src/EnvironmentSetCommand.php
+++ b/src/EnvironmentSetCommand.php
@@ -105,14 +105,7 @@ class EnvironmentSetCommand extends Command
         $value = $this->argument('value');
 
         if (! $value) {
-            $parts = explode('=', $key, 2);
-
-            if (count($parts) !== 2) {
-                throw new InvalidArgumentException('No value was set');
-            }
-
-            $key = $parts[0];
-            $value = $parts[1];
+            $value = ' ';
         }
 
         if (! $this->isValidKey($key)) {


### PR DESCRIPTION
Tried to fix #1, if `$value` is empty, it should just return empty string :D