### PR TITLE
Laravel 6+ support

### DIFF
--- a/src/EnvironmentSetCommand.php
+++ b/src/EnvironmentSetCommand.php
@@ -2,6 +2,7 @@
 
 namespace ImLiam\EnvironmentSetCommand;
 
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Console\Command;
 
@@ -134,7 +135,7 @@ class EnvironmentSetCommand extends Command
      */
     protected function isValidKey(string $key): bool
     {
-        if (str_contains($key, '=')) {
+        if (Str::contains($key, '=')) {
             throw new InvalidArgumentException("Environment key should not contain '='");
         }
 


### PR DESCRIPTION
Minor change to isValidKey method to provide support for Laravel 6+ without installing the laravel/helpers composer package.