### PR TITLE
Keep a record of historic values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "nesbot/carbon": "^2.0"
+        "php": "^7.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1",
+        "nesbot/carbon": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "imliam/laravel-env-set-command",
-    "description": "Set a .env file variable from the command line",
+    "name": "bottlenosecreative/laravel-env-set-command",
+    "description": "Set a .env file variable from the command line - forked from imliam",
     "keywords": [
         "imliam",
         "laravel-env-set-command",

--- a/src/EnvironmentSetCommand.php
+++ b/src/EnvironmentSetCommand.php
@@ -49,9 +49,10 @@ class EnvironmentSetCommand extends Command
         $contents = file_get_contents($envFilePath);
 
         if ($oldValue = $this->getOldValue($contents, $key)) {
-            // Comment out previous value and insert new line underneath - preg_replace to get the "active" key not commented keys
-            $date = \Carbon\Carbon::now()->toDateTimeString();
-            $replace = "#{$key}={$oldValue} # Edited: {$date}\n{$key}={$value}";
+            
+            // Check if history is enabled, if so Comment out previous value and insert new line underneath
+            $date = new Date('y-m-d H:i:s');
+            $replace = env('ENVSET_HISTORY', false) ? "#{$key}={$oldValue} # Edited: {$date}\n{$key}={$value}" : "{$key}={$value}";
             $contents = preg_replace("/^{$key}={$oldValue}[^\r\n]*/m", $replace, $contents);
             
             // Store changes

--- a/src/EnvironmentSetCommand.php
+++ b/src/EnvironmentSetCommand.php
@@ -49,11 +49,10 @@ class EnvironmentSetCommand extends Command
         $contents = file_get_contents($envFilePath);
 
         if ($oldValue = $this->getOldValue($contents, $key)) {
-            // Comment out previous value and insert new line underneath
+            // Comment out previous value and insert new line underneath - preg_replace to get the "active" key not commented keys
             $date = \Carbon\Carbon::now()->toDateTimeString();
-            $contents = str_replace("{$key}={$oldValue}", "#{$key}={$oldValue} # Edited on: {$date}\n{$key}={$value}\n", $contents);
-            // Fix double comments
-            $contents = str_replace("##{$key}", "#{$key}", $contents);
+            $replace = "#{$key}={$oldValue} # Edited: {$date}\n{$key}={$value}";
+            $contents = preg_replace("/^{$key}={$oldValue}[^\r\n]*/m", $replace, $contents);
             
             // Store changes
             $this->writeFile($envFilePath, $contents);

--- a/src/EnvironmentSetCommand.php
+++ b/src/EnvironmentSetCommand.php
@@ -49,7 +49,13 @@ class EnvironmentSetCommand extends Command
         $contents = file_get_contents($envFilePath);
 
         if ($oldValue = $this->getOldValue($contents, $key)) {
-            $contents = str_replace("{$key}={$oldValue}", "{$key}={$value}", $contents);
+            // Comment out previous value and insert new line underneath
+            $date = \Carbon\Carbon::now()->toDateTimeString();
+            $contents = str_replace("{$key}={$oldValue}", "#{$key}={$oldValue} # Edited on: {$date}\n{$key}={$value}\n", $contents);
+            // Fix double comments
+            $contents = str_replace("##{$key}", "#{$key}", $contents);
+            
+            // Store changes
             $this->writeFile($envFilePath, $contents);
 
             return $this->info("Environment variable with key '{$key}' has been changed from '{$oldValue}' to '{$value}'");
@@ -87,7 +93,6 @@ class EnvironmentSetCommand extends Command
     {
         // Match the given key at the beginning of a line
         preg_match("/^{$key}=[^\r\n]*/m", $envFile, $matches);
-
         if (count($matches)) {
             return substr($matches[0], strlen($key) + 1);
         }


### PR DESCRIPTION
Instead of outright deleting/replacing the previous env file key/values, we can comment out the previous value and include a timecode. This helps developers to debug changes made by other users.

To enable history add the following to your .env:

`ENVSET_HISTORY=true`

No idea if others will need this feature, however I needed it for my specific application so figured i'd open a PR while I was at it.

![set-env-example](https://user-images.githubusercontent.com/30525951/82431067-c3f17100-9ac0-11ea-9ec6-331a76240f25.jpg)
