### PR TITLE
Output the old value of the environment key that was updated

### DIFF
--- a/src/EnvironmentSetCommand.php
+++ b/src/EnvironmentSetCommand.php
@@ -59,7 +59,7 @@ class EnvironmentSetCommand extends Command
         if ($isNewVariableSet) {
             $this->info("A new environment variable with key '{$key}' has been set to '{$value}'");
         } else {
-            [$_, $oldValue] = explode('=', $this->readKeyValuePair($content, $key));
+            [$_, $oldValue] = explode('=', $this->readKeyValuePair($content, $key), 2);
             $this->info("Environment variable with key '{$key}' has been changed from '{$oldValue}' to '{$value}'");
         }
 

--- a/src/EnvironmentSetCommand.php
+++ b/src/EnvironmentSetCommand.php
@@ -59,7 +59,8 @@ class EnvironmentSetCommand extends Command
         if ($isNewVariableSet) {
             $this->info("A new environment variable with key '{$key}' has been set to '{$value}'");
         } else {
-            $this->info("Environment variable with key '{$key}' has been updated to '{$value}'");
+            [$_, $oldValue] = explode('=', $this->readKeyValuePair($content, $key));
+            $this->info("Environment variable with key '{$key}' has been changed from '{$oldValue}' to '{$value}'");
         }
 
         $this->writeFile($envFilePath, $newEnvFileContent);


### PR DESCRIPTION
This PR allows the printing of the old value of the environment key that was updated/changed. By doing that, we have the same output as seen in the screenshot and in the README/documentation file.