### PR TITLE
Fixed working with nested key names (for example, APP_KEY and PUSHER_APP_KEY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 
 
+## [1.1.5] - 2020-05-26
+### Fixed
+- Fixed working with nested key names (for example, APP_KEY and PUSHER_APP_KEY).
+
 ## [1.1.4] - 2020-05-13
 ### Added
 - Added the command description.
@@ -47,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial release
 
+[1.1.5]: https://github.com/imliam/laravel-env-set-command/compare/1.1.4...1.1.5
 [1.1.4]: https://github.com/imliam/laravel-env-set-command/compare/1.1.3...1.1.4
 [1.1.3]: https://github.com/imliam/laravel-env-set-command/compare/1.1.2...1.1.3
 [1.1.2]: https://github.com/imliam/laravel-env-set-command/compare/1.1.1...1.1.2

--- a/src/EnvironmentSetCommand.php
+++ b/src/EnvironmentSetCommand.php
@@ -77,14 +77,17 @@ class EnvironmentSetCommand extends Command
      */
     public function setEnvVariable(string $envFileContent, string $key, string $value): array
     {
+        $oldPair = $this->readKeyValuePair($envFileContent, $key);
+        $newPair = $key . '=' . $value;
+
         // For existed key.
-        $oldKeyValuePair = $this->readKeyValuePair($envFileContent, $key);
-        if ($oldKeyValuePair !== null) {
-            return [str_replace($oldKeyValuePair, $key . '=' . $value, $envFileContent), false];
+        if ($oldPair !== null) {
+            $replaced = preg_replace('/^' . preg_quote($oldPair, '/') . '$/uimU', $newPair, $envFileContent);
+            return [$replaced, false];
         }
 
         // For a new key.
-        return [$envFileContent . "\n" . $key . '=' . $value . "\n", true];
+        return [$envFileContent . "\n" . $newPair . "\n", true];
     }
 
     /**
@@ -99,7 +102,7 @@ class EnvironmentSetCommand extends Command
     public function readKeyValuePair(string $envFileContent, string $key): ?string
     {
         // Match the given key at the beginning of a line
-        if (preg_match("#^ *{$key} *= *[^\r\n]*$#imu", $envFileContent, $matches)) {
+        if (preg_match("#^ *{$key} *= *[^\r\n]*$#uimU", $envFileContent, $matches)) {
             return $matches[0];
         }
 
@@ -122,7 +125,7 @@ class EnvironmentSetCommand extends Command
         $envFilePath = null;
 
         // Parse "key=value" key argument.
-        if (preg_match('#^([^=]+)=(.*)$#umu', $_key, $matches)) {
+        if (preg_match('#^([^=]+)=(.*)$#umU', $_key, $matches)) {
             [1 => $key, 2 => $value] = $matches;
 
             // Use second argument as path to env file:
@@ -142,7 +145,7 @@ class EnvironmentSetCommand extends Command
         $this->assertKeyIsValid($key);
 
         // If the value contains spaces but not is not enclosed in quotes.
-        if (preg_match('#^[^\'"].*\s+.*[^\'"]$#um', $value)) {
+        if (preg_match('#^[^\'"].*\s+.*[^\'"]$#umU', $value)) {
             $value = '"' . $value . '"';
         }
 

--- a/tests/Unit/EnvironmentSetCommandTest.php
+++ b/tests/Unit/EnvironmentSetCommandTest.php
@@ -43,6 +43,26 @@ class EnvironmentSetCommandTest extends TestCase
     }
 
     /**
+     * @covers EnvironmentSetCommand::setEnvVariable
+     */
+    public function testSetEnvVariableTestOfNestedKeys(): void
+    {
+        // APP_KEY is a subset of PUSHER_APP_KEY:
+        $env = '# it is a comment' . "\n"
+            . 'APP_KEY=' . "\n"
+            . 'PUSHER_APP_KEY=' . "\n"
+            . 'some_key=some_value' . "\n";
+
+        $expectedEnv = '# it is a comment' . "\n"
+            . 'APP_KEY=test' . "\n"
+            . 'PUSHER_APP_KEY=' . "\n"
+            . 'some_key=some_value' . "\n";
+
+        [$newEnv, $_] = $this->command->setEnvVariable($env, 'APP_KEY', 'test');
+        $this->assertEquals($expectedEnv, $newEnv);
+    }
+
+    /**
      * @covers       EnvironmentSetCommand::readKeyValuePair
      * @dataProvider readKeyValuePairDataProvider
      *
@@ -91,6 +111,7 @@ class EnvironmentSetCommandTest extends TestCase
      */
     public function setEnvVariableDataProvider(): array
     {
+        // Unfortunately, we can't test nested key names using str_replace().
         $envFileContent = $this->getTestEnvFile();
         return [
             [


### PR DESCRIPTION
There is a serious bug now if the .env file contains "nested" keys (for example, APP_KEY and PUSHER_APP_KEY, each modern laravel instance, lol).
At first we have this env-file:
```env
APP_KEY=
MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
```
Run command:
```bash
php artisan env:set APP_KEY test
```
Get this output:
```env
APP_KEY=test
MIX_PUSHER_APP_KEY=test"${PUSHER_APP_KEY}"
```
I have fixed this, added the unit-test for checking this behavior.