### PR TITLE
Values with spaces break application

### DIFF
--- a/src/EnvironmentSetCommand.php
+++ b/src/EnvironmentSetCommand.php
@@ -78,7 +78,7 @@ class EnvironmentSetCommand extends Command
     public function setEnvVariable(string $envFileContent, string $key, string $value): array
     {
         $oldPair = $this->readKeyValuePair($envFileContent, $key);
-        $newPair = $key . '=' . $value;
+        $newPair = $key . '="' . $value . '"';
 
         // For existed key.
         if ($oldPair !== null) {

--- a/src/EnvironmentSetCommand.php
+++ b/src/EnvironmentSetCommand.php
@@ -78,7 +78,13 @@ class EnvironmentSetCommand extends Command
     public function setEnvVariable(string $envFileContent, string $key, string $value): array
     {
         $oldPair = $this->readKeyValuePair($envFileContent, $key);
-        $newPair = $key . '="' . $value . '"';
+
+        // Wrap values that have a space or equals in quotes to escape them
+        if (preg_match('/\s/',$value) || strpos($value, '=') !== false) {
+            $value = '"' . $value . '"';
+        }
+
+        $newPair = $key . '=' . $value;
 
         // For existed key.
         if ($oldPair !== null) {

--- a/tests/Unit/EnvironmentSetCommandTest.php
+++ b/tests/Unit/EnvironmentSetCommandTest.php
@@ -181,7 +181,14 @@ class EnvironmentSetCommandTest extends TestCase
                 'some_key',
                 '=========',
                 str_replace('some_key=some_value',
-                    'some_key==========', $envFileContent),
+                    'some_key="========="', $envFileContent),
+            ],
+            [
+                &$envFileContent,
+                'value_with_spaces',
+                'this is a value',
+                str_replace('value_with_spaces=',
+                    'value_with_spaces="this is a value"', $envFileContent),
             ],
         ];
     }
@@ -353,6 +360,7 @@ class EnvironmentSetCommandTest extends TestCase
             . '    spaces_in_the_quotes    =    "    "    ' . "\n"
             . 'a_lot_of_equals_signs_one=======' . "\n"
             . 'a_lot_of_equals_signs_two    =    ======    ' . "\n"
-            . 'a_lot_of_equals_signs_three    =    "======"    ' . "\n";
+            . 'a_lot_of_equals_signs_three    =    "======"    ' . "\n"
+            . 'value_with_spaces=' . "\n";
     }
 }


### PR DESCRIPTION
Setting app name to: My Company Name will break the .env file.

https://cln.sh/BNoLe8sCHBTu7vuzrouz+

```
The environment file is invalid!
Failed to parse dotenv file due to unexpected whitespace. Failed at [My Company Name].
```

E.g. Ploi Is Awesome Company vs "Ploi Is Awesome Company"