### PR TITLE
Add PHP 8 Support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       max-parallel: 15
       fail-fast: false
       matrix:
-        php-versions: ["7.3", "7.4"]
+        php-versions: ["7.3", "7.4", "8.0"]
         composer-flags: ["--prefer-lowest", "--prefer-stable"]
         env:
           - LARAVEL_VERSION='^7.0'

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "illuminate/support": "^7.0|^8.0",
         "illuminate/console": "^7.0|^8.0"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,9 +8,6 @@
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
     </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">


### PR DESCRIPTION
This PR adds `^8.0` to the PHP dependency, and removes the `Feature` test config from PHPUnit as this was causing an error when running tests (since no feature tests exist). All tests pass on my end.

- Closes #24